### PR TITLE
Change the NFS export path mapping to work with the Kubernetes Agent

### DIFF
--- a/ganesha.conf
+++ b/ganesha.conf
@@ -9,8 +9,8 @@ LOG {
 
 
 	COMPONENTS {
-		# Uncomment line below for full debugging
-		# ALL = FULL_DEBUG;
+		# Uncomment line below for full debug logging
+		ALL = FULL_DEBUG;
 
 		NFS_V4 = INFO; 
 		EXPORT = INFO;

--- a/ganesha.conf
+++ b/ganesha.conf
@@ -1,5 +1,5 @@
 LOG {
-	Default_Log_Level = INFO;
+	Default_Log_Level = WARN;
 
 	Facility {
 		name = FILE;
@@ -7,11 +7,13 @@ LOG {
 		enable = active;
 	}
 
-# 	uncomment to enable debug logging
+
 	COMPONENTS {
-		NFS_V4 = FULL_DEBUG; 
-		FSAL=FULL_DEBUG;
-		EXPORTS=FULL_DEBUG;
+		# Uncomment line below for full debugging
+		# ALL = FULL_DEBUG;
+
+		NFS_V4 = INFO; 
+		EXPORT = INFO;
 	}
 }
 
@@ -30,7 +32,7 @@ EXPORT
 	Path = /octopus;
 
 	# Pseudo Path (required for NFS v4)
-	Pseudo = /octopus;
+	Pseudo = /;
 
 	Protocols = 4;
 


### PR DESCRIPTION
## Background

The `Export.Pseudo` option in the [Ganesha config](https://www.mankier.com/8/ganesha-export-config) specifies 

> the position in the Pseudo Filesystem this export occupies if this is an NFS v4 export.

It is currently set to `/octopus` which means that the Kubernetes Agent (the NFS client) has to access the NFS via `/octopus/octopus`, since the [volume mount path](https://github.com/OctopusDeploy/helm-charts/blob/main/charts/kubernetes-agent/templates/tentacle-deployment.yaml#L191) of the Agent is also `/octopus`.

## Result

### File export config
Changed the `Export.Pseudo` option from `/octopus` to `/` so that the exported directory is exported as the root share.

### Log config
Changed the default log level to WARN and adjusted the NFS_V4 and EXPORT log components to INFO. This update is separate from the file export changes and is aimed at reducing log noise, as the previous FULL_DEBUG setting was generating excessive log entries. The full list of log levels and components can be found [here](https://www.mankier.com/8/ganesha-log-config).